### PR TITLE
Vue-CLI / webpack documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,28 @@ import 'vue-octicon/icons'
 
 **Heads up**
 
-if you are using `vue-cli` to create your project, the `webpack` template may exclude `node_modules` from files to be transpiled by Babel. Change the `exclude` value from `/node_modules/` to `/node_modules(?![\\/]vue-octicon[\\/])/` to fix the problem.**
+if you are using `vue-cli` to create your project, the `webpack` template may exclude `node_modules` from files to be transpiled by Babel. 
+
+To fix this my creating an exception, edit your webpack config:
+
+> In older versions of vue-cli: 
+
+Change the `exclude` value from `/node_modules/` to `/node_modules(?![\\/]vue-octicon[\\/])/`.
+
+> In the latest version of vue-cli (as of Oct. 2017):
+
+```js
+// Change this code
+test: /\.js$/,
+        loader: 'babel-loader',
+        include: [resolve('src'), resolve('test')]
+// to this code
+
+
+test: /\.js$/,
+        loader: 'babel-loader',
+        include: [resolve('src'), resolve('test'), resolve('node_modules/vue-octicon')]
+```
 
 ### CommonJS with NPM without ES Next support
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import 'vue-octicon/icons'
 
 if you are using `vue-cli` to create your project, the `webpack` template may exclude `node_modules` from files to be transpiled by Babel. 
 
-To fix this you will need to edit `/build/webpack.base.conf.js`
+To fix this you will need to edit `/build/webpack.base.conf.js`. If you do not do this, UglifyJS will halt your build with an error as it cannot parse ES2015 syntax.
 
 ##### In the latest version of vue-cli (as of Oct. 2017):
 

--- a/README.md
+++ b/README.md
@@ -59,19 +59,20 @@ if you are using `vue-cli` to create your project, the `webpack` template may ex
 
 To fix this my creating an exception, edit your webpack config:
 
-> In older versions of vue-cli: 
+#### In older versions of vue-cli: 
 
 Change the `exclude` value from `/node_modules/` to `/node_modules(?![\\/]vue-octicon[\\/])/`.
 
-> In the latest version of vue-cli (as of Oct. 2017):
+#### In the latest version of vue-cli (as of Oct. 2017):
 
 ```js
-// Change this code
+// Find where webpack looks for files to run through babel
+
 test: /\.js$/,
         loader: 'babel-loader',
         include: [resolve('src'), resolve('test')]
-// to this code
 
+// and change it to this, so it knows to go get and transpile vue-octicon too
 
 test: /\.js$/,
         loader: 'babel-loader',

--- a/README.md
+++ b/README.md
@@ -53,17 +53,13 @@ import 'vue-octicon/icons/repo'
 import 'vue-octicon/icons'
 ```
 
-**Heads up**
+#### Heads up
 
 if you are using `vue-cli` to create your project, the `webpack` template may exclude `node_modules` from files to be transpiled by Babel. 
 
-To fix this my creating an exception, edit your webpack config:
+To fix this you will need to edit `/build/webpack.base.conf.js`
 
-#### In older versions of vue-cli: 
-
-Change the `exclude` value from `/node_modules/` to `/node_modules(?![\\/]vue-octicon[\\/])/`.
-
-#### In the latest version of vue-cli (as of Oct. 2017):
+##### In the latest version of vue-cli (as of Oct. 2017):
 
 ```js
 // Find where webpack looks for files to run through babel
@@ -78,6 +74,11 @@ test: /\.js$/,
         loader: 'babel-loader',
         include: [resolve('src'), resolve('test'), resolve('node_modules/vue-octicon')]
 ```
+
+##### In older versions of vue-cli: 
+
+Change the `exclude` value from `/node_modules/` to `/node_modules(?![\\/]vue-octicon[\\/])/`.
+
 
 ### CommonJS with NPM without ES Next support
 


### PR DESCRIPTION
The readme describes adding a regex to an exclude statement in webpack's config in order to use this with vue-cli.

I'm not sure when things changed, but as of today there is no exclude node_modules statement in their config. They explicitly include `src` and `test` instead. 

This PR addresses that by adding their current configuration, what needs to be changed to in order to get a successful build, and a brief description of what that's doing/why. I've left the old regex alongside in case someone is using another version.